### PR TITLE
Add parameter for AdvertiseAddress

### DIFF
--- a/config_defaults.json
+++ b/config_defaults.json
@@ -23,8 +23,9 @@
   "inx": {
     "address": "localhost:9029"
   },
-  "poi": {
-    "bindAddress": "localhost:9687",
+  "restAPI": {
+    "bindAddress": "localhost:9091",
+    "advertiseAddress": "",
     "debugRequestLoggerEnabled": false
   },
   "profiling": {

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -24,7 +24,7 @@
     "address": "localhost:9029"
   },
   "restAPI": {
-    "bindAddress": "localhost:9091",
+    "bindAddress": "localhost:9687",
     "advertiseAddress": "",
     "debugRequestLoggerEnabled": false
   },

--- a/core/poi/params.go
+++ b/core/poi/params.go
@@ -4,18 +4,23 @@ import (
 	"github.com/iotaledger/hive.go/core/app"
 )
 
-type ParametersPOI struct {
-	BindAddress string `default:"localhost:9687" usage:"bind address on which the POI HTTP server listens"`
+// ParametersRestAPI contains the definition of the parameters used by the POI HTTP server.
+type ParametersRestAPI struct {
+	// BindAddress defines the bind address on which the POI HTTP server listens.
+	BindAddress string `default:"localhost:9091" usage:"the bind address on which the POI HTTP server listens"`
+
+	// AdvertiseAddress defines the address of the POI HTTP server which is advertised to the INX Server (optional).
+	AdvertiseAddress string `default:"" usage:"the address of the POI HTTP server which is advertised to the INX Server (optional)"`
 
 	// DebugRequestLoggerEnabled defines whether the debug logging for requests should be enabled
 	DebugRequestLoggerEnabled bool `default:"false" usage:"whether the debug logging for requests should be enabled"`
 }
 
-var ParamsPOI = &ParametersPOI{}
+var ParamsRestAPI = &ParametersRestAPI{}
 
 var params = &app.ComponentParams{
 	Params: map[string]any{
-		"poi": ParamsPOI,
+		"restAPI": ParamsRestAPI,
 	},
 	Masked: nil,
 }

--- a/core/poi/params.go
+++ b/core/poi/params.go
@@ -7,7 +7,7 @@ import (
 // ParametersRestAPI contains the definition of the parameters used by the POI HTTP server.
 type ParametersRestAPI struct {
 	// BindAddress defines the bind address on which the POI HTTP server listens.
-	BindAddress string `default:"localhost:9091" usage:"the bind address on which the POI HTTP server listens"`
+	BindAddress string `default:"localhost:9687" usage:"the bind address on which the POI HTTP server listens"`
 
 	// AdvertiseAddress defines the address of the POI HTTP server which is advertised to the INX Server (optional).
 	AdvertiseAddress string `default:"" usage:"the address of the POI HTTP server which is advertised to the INX Server (optional)"`

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -125,7 +125,7 @@ Example:
 
 | Name                      | Description                                                                         | Type    | Default value    |
 | ------------------------- | ----------------------------------------------------------------------------------- | ------- | ---------------- |
-| bindAddress               | The bind address on which the POI HTTP server listens                               | string  | "localhost:9091" |
+| bindAddress               | The bind address on which the POI HTTP server listens                               | string  | "localhost:9687" |
 | advertiseAddress          | The address of the POI HTTP server which is advertised to the INX Server (optional) | string  | ""               |
 | debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled                            | boolean | false            |
 
@@ -134,7 +134,7 @@ Example:
 ```json
   {
     "restAPI": {
-      "bindAddress": "localhost:9091",
+      "bindAddress": "localhost:9687",
       "advertiseAddress": "",
       "debugRequestLoggerEnabled": false
     }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -121,19 +121,21 @@ Example:
   }
 ```
 
-## <a id="poi"></a> 4. Proof-Of-Inclusion
+## <a id="restapi"></a> 4. RestAPI
 
-| Name                      | Description                                              | Type    | Default value    |
-| ------------------------- | -------------------------------------------------------- | ------- | ---------------- |
-| bindAddress               | Bind address on which the POI HTTP server listens        | string  | "localhost:9687" |
-| debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled | boolean | false            |
+| Name                      | Description                                                                         | Type    | Default value    |
+| ------------------------- | ----------------------------------------------------------------------------------- | ------- | ---------------- |
+| bindAddress               | The bind address on which the POI HTTP server listens                               | string  | "localhost:9091" |
+| advertiseAddress          | The address of the POI HTTP server which is advertised to the INX Server (optional) | string  | ""               |
+| debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled                            | boolean | false            |
 
 Example:
 
 ```json
   {
-    "poi": {
-      "bindAddress": "localhost:9687",
+    "restAPI": {
+      "bindAddress": "localhost:9091",
+      "advertiseAddress": "",
       "debugRequestLoggerEnabled": false
     }
   }


### PR DESCRIPTION
This PR introduces the `AdvertiseAddress` config parameter, which simplifies the setup in some private network environments.