### PR TITLE
Add routes to same group (APIRoute)

### DIFF
--- a/components/poi/component.go
+++ b/components/poi/component.go
@@ -76,7 +76,8 @@ func run() error {
 
 		Component.LogInfo("Starting API server ...")
 
-		setupRoutes(e)
+		setupRoutes(e.Group(APIRoute))
+
 		go func() {
 			Component.LogInfof("You can now access the API using: http://%s", ParamsRestAPI.BindAddress)
 			if err := e.Start(ParamsRestAPI.BindAddress); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/components/poi/routes.go
+++ b/components/poi/routes.go
@@ -18,9 +18,9 @@ const (
 	RouteValidateProof = "/validate"
 )
 
-func setupRoutes(e *echo.Echo) {
+func setupRoutes(routeGroup *echo.Group) {
 
-	e.GET(RouteCreateProof, func(c echo.Context) error {
+	routeGroup.GET(RouteCreateProof, func(c echo.Context) error {
 		resp, err := createProof(c)
 		if err != nil {
 			return err
@@ -29,7 +29,7 @@ func setupRoutes(e *echo.Echo) {
 		return httpserver.JSONResponse(c, http.StatusOK, resp)
 	})
 
-	e.POST(RouteValidateProof, func(c echo.Context) error {
+	routeGroup.POST(RouteValidateProof, func(c echo.Context) error {
 		resp, err := validateProof(c)
 		if err != nil {
 			return err


### PR DESCRIPTION
INX forwarding only works when the plugin routes are defined as `echo.Group`.